### PR TITLE
Eh create net static runtime ffi

### DIFF
--- a/native/adbflib/src/ctrl/mod.rs
+++ b/native/adbflib/src/ctrl/mod.rs
@@ -11,7 +11,7 @@ use super::{
     net::subs::peer_representation::{self, PeerRepresentation},
 };
 use async_std::task;
-use crossbeam::sync::WaitGroup;
+use crossbeam::{sync::WaitGroup, Receiver as CReceiver};
 use libp2p_core::PeerId;
 use std::{
     collections::hash_map::DefaultHasher,
@@ -125,7 +125,7 @@ impl Ctrl {
     pub fn run(
         new_id: PeerId,
         paths: Arc<Mutex<SearchPath>>,
-        receiver: Receiver<UiUpdateMsg>,
+        receiver: CReceiver<UiUpdateMsg>,
         with_net: bool,
         wait_main: WaitGroup,
         has_webui: bool,
@@ -322,7 +322,7 @@ impl Ctrl {
     }
 
     fn spawn_message_loop(
-        receiver: Receiver<UiUpdateMsg>,
+        receiver: CReceiver<UiUpdateMsg>,
         multiplex_send: Vec<Sender<InternalUiMsg>>,
     ) -> Result<thread::JoinHandle<()>, std::io::Error> {
         thread::Builder::new()
@@ -404,7 +404,7 @@ impl Ctrl {
     /// which kind of defines an extra layer for convenience, and to
     /// be extended and so on.
     fn run_message_forwarding(
-        receiver: &Receiver<UiUpdateMsg>,
+        receiver: &CReceiver<UiUpdateMsg>,
         multiplex_send: &Vec<Sender<InternalUiMsg>>,
     ) -> bool {
         if let Ok(forward_sys_message) = receiver.recv() {

--- a/native/adbflib/src/ctrl/tui/mod.rs
+++ b/native/adbflib/src/ctrl/tui/mod.rs
@@ -254,7 +254,7 @@ impl Tui {
 
     ///    # Example test
     ///  ```
-    ///  use adbflib::ctrl::tui::Tui;
+    ///  use adbfbinlib::ctrl::tui::Tui;
     ///
     ///  let boundary = 15;
     ///  let input_vec: Vec<String> =
@@ -262,7 +262,7 @@ impl Tui {
     ///         "A cool hat does not fit you.".into()];
     ///  let expected_output: Vec<String> =
     ///     vec!["The duc..mming.".into(), "A cool ..t you.".into()];
-    ///  let output = adbflib::ctrl::tui::Tui::split_intelligently_ralign_vec(&input_vec, boundary);
+    ///  let output = adbfbinlib::ctrl::tui::Tui::split_intelligently_ralign_vec(&input_vec, boundary);
     ///  ```
     // todo: not public... only due to testing
     pub fn split_intelligently_ralign_vec(vec: &Vec<String>, max_len: usize) -> Vec<String> {

--- a/native/adbflib/src/data/mod.rs
+++ b/native/adbflib/src/data/mod.rs
@@ -8,11 +8,11 @@ mod tag_readers;
 
 use self::{audio_info::Container, collection::Collection, ipc::IPC};
 use super::ctrl::{CollectionPathAlive, ForwardNetMsg, NetInfoMsg, Status, UiUpdateMsg};
-use crossbeam::channel::Sender as CrossbeamSender;
+use crossbeam::channel::Sender as CSender;
 use std::{
     ops::Add,
     path::Path,
-    sync::{mpsc::Sender, Arc as SArc, Mutex as SMutex},
+    sync::{Arc as SArc, Mutex as SMutex},
 };
 
 /// Interface of what collection output data will return
@@ -48,7 +48,7 @@ pub fn search_in_single_path(
     has_ui: bool,
     collection_data: SArc<SMutex<Container>>,
     collection_protected: SArc<SMutex<Collection>>,
-    mutex_to_ui_msg: SArc<SMutex<Sender<UiUpdateMsg>>>,
+    mutex_to_ui_msg: SArc<SMutex<CSender<UiUpdateMsg>>>,
     index: usize,
     elem: &str,
 ) -> IFInternalCollectionOutputData {
@@ -150,10 +150,7 @@ pub fn search_in_single_path(
 }
 
 #[allow(dead_code)]
-pub fn publish_local_storage(
-    container_handle: SArc<SMutex<Container>>,
-    ipc_sender: CrossbeamSender<IPC>,
-) {
+pub fn publish_local_storage(container_handle: SArc<SMutex<Container>>, ipc_sender: CSender<IPC>) {
     // send to ipc
     //
     let container = container_handle.lock().unwrap();

--- a/native/adbflib/src/net/ui_data.rs
+++ b/native/adbflib/src/net/ui_data.rs
@@ -5,15 +5,16 @@ use super::{
     sm::*,
     subs::peer_representation,
 };
+use crossbeam::Sender as CSender;
 use libp2p_core::{Multiaddr, PeerId};
-use std::{collections::HashSet, sync::mpsc::Sender};
+use std::collections::HashSet;
 
 pub struct UiData {
-    sender: Option<Sender<UiUpdateMsg>>,
+    sender: Option<CSender<UiUpdateMsg>>,
     ui_shown_peers: HashSet<PeerId>,
 }
 impl UiData {
-    pub fn new(sender: Option<Sender<UiUpdateMsg>>) -> Self {
+    pub fn new(sender: Option<CSender<UiUpdateMsg>>) -> Self {
         Self {
             sender,
             ui_shown_peers: HashSet::new(),


### PR DESCRIPTION
enables (lazy) static net functionality ... which also only prints out new(!) peers found in app. Because while running, new peers are simply ignored in app once started and not request again.